### PR TITLE
fix(autowidth): checking extraneous filetype

### DIFF
--- a/lua/windows/autowidth.lua
+++ b/lua/windows/autowidth.lua
@@ -65,6 +65,7 @@ function M.enable()
       if win:is_floating()
          or (new_window and win:is_ignored())
          or win:get_type() == 'command' -- "[Command Line]" window
+         or win:get_type() == ''
       then
          return
       end


### PR DESCRIPTION
Some plugins will create splits in windows that do not initially have a file type. This can be problematic as the auto command will fire and resize that window. We do not want to resize these windows as usually they are information windows such as Lazy and Mason opening up floating windows. 

However, floating windows are already ignored, some plugins just open up vertical splits to show some information and forego including a file type initially or at all.

This pull request does not affect the `:vsplit` or `:vnew` commands as those do contain a file type initially, those commands still work and will be automagically resized. It seems to only affect some plugins whose authors do not set a file type explicitly when opening up a new vertical split. Something like LSPSaga's code outline has this issue.